### PR TITLE
feat: Add ddk-archguard-starter module

### DIFF
--- a/ddk-starters/ddk-archguard-starter/pom.xml
+++ b/ddk-starters/ddk-archguard-starter/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.ddk</groupId>
+        <artifactId>domain-driven-kit</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../../../domain-driven-kit</relativePath>
+    </parent>
+
+    <artifactId>ddk-archguard-starter</artifactId>
+
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.ddk</groupId>
+            <artifactId>ddk-core</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
+        </dependency>
+
+        <!-- ArchGuard dependencies will be added here -->
+
+    </dependencies>
+
+</project>

--- a/ddk-starters/ddk-archguard-starter/src/main/java/com/ddk/archguard/starter/config/ArchGuardAutoConfiguration.java
+++ b/ddk-starters/ddk-archguard-starter/src/main/java/com/ddk/archguard/starter/config/ArchGuardAutoConfiguration.java
@@ -1,0 +1,8 @@
+package com.ddk.archguard.starter.config;
+
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ArchGuardAutoConfiguration {
+
+}

--- a/ddk-starters/ddk-archguard-starter/src/test/java/com/ddk/archguard/starter/config/ArchGuardAutoConfigurationTest.java
+++ b/ddk-starters/ddk-archguard-starter/src/test/java/com/ddk/archguard/starter/config/ArchGuardAutoConfigurationTest.java
@@ -1,0 +1,19 @@
+package com.ddk.archguard.starter.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ArchGuardAutoConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(ArchGuardAutoConfiguration.class));
+
+    @Test
+    void archGuardAutoConfigurationShouldBeLoaded() {
+        contextRunner.run(context -> {
+            assertThat(context).hasSingleBean(ArchGuardAutoConfiguration.class);
+        });
+    }
+}

--- a/ddk-starters/pom.xml
+++ b/ddk-starters/pom.xml
@@ -14,6 +14,7 @@
 
     <modules>
         <module>ddk-web-starter</module>
+        <module>ddk-archguard-starter</module>
     </modules>
 
 </project>


### PR DESCRIPTION
This commit introduces a new starter module, `ddk-archguard-starter`, under the `ddk-starters` directory.

Key changes include:
- Creation of the `ddk-archguard-starter` directory and its `pom.xml`. The POM is structured similarly to other starters and includes a placeholder for specific ArchGuard dependencies.
- Update of the parent `ddk-starters/pom.xml` to include the new `ddk-archguard-starter` module.
- Addition of a placeholder Spring auto-configuration class, `com.ddk.archguard.starter.config.ArchGuardAutoConfiguration`.
- Creation of a basic unit test, `ArchGuardAutoConfigurationTest`, to ensure the auto-configuration class loads correctly within a Spring application context.

Note: Specific ArchGuard dependencies need to be identified and added to `ddk-archguard-starter/pom.xml` to make the starter fully functional.