### PR TITLE
refactor: Enhance ddk-archguard-starter with ArchUnit

### DIFF
--- a/ddk-starters/ddk-archguard-starter/README.md
+++ b/ddk-starters/ddk-archguard-starter/README.md
@@ -1,0 +1,85 @@
+# DDK ArchGuard Starter
+
+This starter helps integrate ArchUnit into your DDK project for architecture governance.
+It provides core ArchUnit dependencies and a set of predefined architectural rules.
+
+## Features
+
+- Provides `archunit-junit5-api` and `archunit-junit5-engine` dependencies.
+- Includes `CommonArchRules.java` with a predefined layered architecture rule (`CommonArchRules.LAYERED_ARCHITECTURE_RULE`).
+
+## Prerequisites
+
+Your project should be set up to use JUnit 5 for ArchUnit tests.
+
+## How to Use
+
+1.  **Include the starter in your project's `pom.xml`:**
+
+    ```xml
+    <dependency>
+        <groupId>com.ddk</groupId>
+        <artifactId>ddk-archguard-starter</artifactId>
+        <version>${ddk.version}</version> <!-- Ensure this matches your project's ddk version -->
+        <scope>test</scope> <!-- Typically, architecture tests are in test scope -->
+    </dependency>
+    ```
+
+2.  **Create an ArchUnit test class:**
+
+    In your test sources (e.g., `src/test/java/com/example/architecture/ArchitectureTest.java`):
+
+    ```java
+    import com.tngtech.archunit.core.importer.ClassFileImporter;
+    import com.tngtech.archunit.core.domain.JavaClasses;
+    import com.tngtech.archunit.junit.AnalyzeClasses;
+    import com.tngtech.archunit.junit.ArchTest;
+    import com.tngtech.archunit.lang.ArchRule;
+    import static com.ddk.archguard.starter.rules.CommonArchRules.LAYERED_ARCHITECTURE_RULE;
+    // If you have your own rules or want to customize:
+    // import static com.tngtech.archunit.library.Architectures.layeredArchitecture;
+
+
+    // Specify the packages to analyze
+    @AnalyzeClasses(packages = "com.example.yourproject")
+    public class ArchitectureTest {
+
+        @ArchTest
+        public static final ArchRule checkLayeredArchitecture = LAYERED_ARCHITECTURE_RULE;
+
+        // Example of a custom rule if needed:
+        // @ArchTest
+        // public static final ArchRule myCustomRule = layeredArchitecture()
+        //     .consideringAllDependencies()
+        //     .layer("MyService").definedBy("..service..")
+        //     .layer("MyRepository").definedBy("..repository..")
+        //     .whereLayer("MyService").mayOnlyAccessLayers("MyRepository");
+    }
+    ```
+
+3.  **Customize Package Identifiers in Rules (Important):**
+
+    The predefined `LAYERED_ARCHITECTURE_RULE` in `CommonArchRules` uses generic package identifiers like `"..ui.."` or `"..application.."`. You will likely need to adjust these to match your project's actual package structure.
+
+    To do this, you can either:
+    a. Copy the rule definition from `CommonArchRules.java` into your `ArchitectureTest.java` and modify the `definedBy(...)` parts.
+    b. (Advanced) If the starter evolves, it might provide a way to configure these package names.
+
+## Provided Rules
+
+-   **`CommonArchRules.LAYERED_ARCHITECTURE_RULE`**:
+    Checks for adherence to a typical layered architecture:
+    - UI layer (`..ui..`, `..adapter..`)
+    - Application layer (`..application..`)
+    - Domain layer (`..domain..`)
+    - Infrastructure layer (`..infrastructure..`)
+
+    Access permissions:
+    - UI: Should not be accessed by other layers.
+    - Application: May only be accessed by UI.
+    - Domain: May only be accessed by Application and Infrastructure.
+    - Infrastructure: May only be accessed by Application and Domain.
+
+## Further Customization
+
+You can define your own ArchUnit rules alongside or instead of the provided ones. Refer to the [ArchUnit documentation](https://www.archunit.org/userguide/html/000_Index.html) for more details on writing rules.

--- a/ddk-starters/ddk-archguard-starter/pom.xml
+++ b/ddk-starters/ddk-archguard-starter/pom.xml
@@ -25,8 +25,18 @@
             <version>1.0.0-SNAPSHOT</version>
         </dependency>
 
-        <!-- ArchGuard dependencies will be added here -->
-
+        <dependency>
+            <groupId>com.tngtech.archunit</groupId>
+            <artifactId>archunit-junit5-api</artifactId>
+            <version>1.2.1</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.tngtech.archunit</groupId>
+            <artifactId>archunit-junit5-engine</artifactId>
+            <version>1.2.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/ddk-starters/ddk-archguard-starter/src/main/java/com/ddk/archguard/starter/rules/CommonArchRules.java
+++ b/ddk-starters/ddk-archguard-starter/src/main/java/com/ddk/archguard/starter/rules/CommonArchRules.java
@@ -1,0 +1,22 @@
+package com.ddk.archguard.starter.rules;
+
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.library.Architectures;
+
+public final class CommonArchRules {
+
+    private CommonArchRules() {
+    }
+
+    public static final ArchRule LAYERED_ARCHITECTURE_RULE = Architectures.layeredArchitecture()
+            .consideringAllDependencies()
+            .layer("UI").definedBy("..ui..", "..adapter..")
+            .layer("Application").definedBy("..application..")
+            .layer("Domain").definedBy("..domain..")
+            .layer("Infrastructure").definedBy("..infrastructure..")
+
+            .whereLayer("UI").mayNotBeAccessedByAnyLayer()
+            .whereLayer("Application").mayOnlyBeAccessedByLayers("UI")
+            .whereLayer("Domain").mayOnlyBeAccessedByLayers("Application", "Infrastructure") // Infrastructure can access Domain for repository implementations
+            .whereLayer("Infrastructure").mayOnlyBeAccessedByLayers("Application", "Domain");
+}

--- a/ddk-starters/ddk-archguard-starter/src/test/java/com/ddk/archguard/starter/config/ArchGuardAutoConfigurationTest.java
+++ b/ddk-starters/ddk-archguard-starter/src/test/java/com/ddk/archguard/starter/config/ArchGuardAutoConfigurationTest.java
@@ -5,6 +5,10 @@ import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.ddk.archguard.starter.rules.CommonArchRules;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.domain.JavaClasses;
+
 public class ArchGuardAutoConfigurationTest {
 
     private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
@@ -15,5 +19,13 @@ public class ArchGuardAutoConfigurationTest {
         contextRunner.run(context -> {
             assertThat(context).hasSingleBean(ArchGuardAutoConfiguration.class);
         });
+    }
+
+    @Test
+    void common_arch_rules_should_be_accessible() {
+        assertThat(CommonArchRules.LAYERED_ARCHITECTURE_RULE).isNotNull();
+
+        JavaClasses importedClasses = new ClassFileImporter().importClasses(CommonArchRules.class);
+        assertThat(importedClasses).isNotEmpty();
     }
 }


### PR DESCRIPTION
This commit significantly enhances the `ddk-archguard-starter` by integrating ArchUnit for architecture governance, aligning with the project's README.

Key changes:
- Added `archunit-junit5-api` and `archunit-junit5-engine` dependencies to `ddk-archguard-starter/pom.xml`.
- Introduced `CommonArchRules.java` in `com.ddk.archguard.starter.rules` which provides a predefined layered architecture rule (`LAYERED_ARCHITECTURE_RULE`). This rule helps enforce common DDD layering conventions (UI, Application, Domain, Infrastructure).
- Updated `ArchGuardAutoConfigurationTest.java` to include a basic test verifying the accessibility of `CommonArchRules`.
- Created a `README.md` within `ddk-starters/ddk-archguard-starter/` detailing the starter's features, how to include it, and how to use the predefined rules in an ArchUnit test.

The placeholder `ArchGuardAutoConfiguration.java` remains, as the primary function of this starter is now to provide ArchUnit dependencies and predefined rules rather than active Spring auto-configuration.